### PR TITLE
Ssl support

### DIFF
--- a/connection_producer.go
+++ b/connection_producer.go
@@ -141,10 +141,6 @@ func (c *YugabyteDBConnectionProducer) Connection(ctx context.Context) (interfac
 		c.SslRootCert = ""
 	}
 
-	if c.SslMode != "verify-full" && c.SslMode != "verify-ca" {
-		c.SslRootCert = ""
-	}
-
 	var conn string
 	if c.TopologyKeys != "" {
 		conn = fmt.Sprintf("host=%s port=%d user=%s "+

--- a/connection_producer.go
+++ b/connection_producer.go
@@ -40,6 +40,8 @@ type YugabyteDBConnectionProducer struct {
 	LoadBalance              bool        `json:"load_balance" mapstructure:"load_balance" structs:"load_balance"`
 	YbServersRefreshInterval int         `json:"yb_servers_refresh_interval" mapstructure:"yb_servers_refresh_interval" structs:"yb_servers_refresh_interval"`
 	TopologyKeys             string      `json:"topology_keys" mapstructure:"topology_keys" structs:"topology_keys"`
+	SslMode                  string      `json:"sslmode" mapstructure:"sslmode" structs:"sslmode"`
+	SslRootCert              string      `json:"sslrootcert" mapstructure:"sslrootcert" structs:"sslrootcert"`
 
 	Type                  string
 	RawConfig             map[string]interface{}
@@ -134,13 +136,22 @@ func (c *YugabyteDBConnectionProducer) Connection(ctx context.Context) (interfac
 		c.db.Close()
 	}
 
+	if c.SslMode == "" {
+		c.SslMode = "disable"
+		c.SslRootCert = ""
+	}
+
+	if c.SslMode != "verify-full" && c.SslMode != "verify-ca" {
+		c.SslRootCert = ""
+	}
+
 	var conn string
 	if c.TopologyKeys != "" {
 		conn = fmt.Sprintf("host=%s port=%d user=%s "+
-			"password=%s dbname=%s sslmode=disable load_balance=%v yb_servers_refresh_interval=%d topology_keys=%s ", c.Host, c.Port, c.Username, c.Password, c.DbName, c.LoadBalance, c.YbServersRefreshInterval, c.TopologyKeys)
+			"password=%s dbname=%s sslmode=%s sslrootcert=%s load_balance=%v yb_servers_refresh_interval=%d topology_keys=%s ", c.Host, c.Port, c.Username, c.Password, c.DbName, c.SslMode, c.SslRootCert, c.LoadBalance, c.YbServersRefreshInterval, c.TopologyKeys)
 	} else {
 		conn = fmt.Sprintf("host=%s port=%d user=%s "+
-			"password=%s dbname=%s sslmode=disable load_balance=%v yb_servers_refresh_interval=%d ", c.Host, c.Port, c.Username, c.Password, c.DbName, c.LoadBalance, c.YbServersRefreshInterval)
+			"password=%s dbname=%s sslmode=%s sslrootcert=%s load_balance=%v yb_servers_refresh_interval=%d ", c.Host, c.Port, c.Username, c.Password, c.DbName, c.SslMode, c.SslRootCert, c.LoadBalance, c.YbServersRefreshInterval)
 	}
 
 	if len(c.ConnectionURL) != 0 {

--- a/connection_producer.go
+++ b/connection_producer.go
@@ -42,6 +42,10 @@ type YugabyteDBConnectionProducer struct {
 	TopologyKeys             string      `json:"topology_keys" mapstructure:"topology_keys" structs:"topology_keys"`
 	SslMode                  string      `json:"sslmode" mapstructure:"sslmode" structs:"sslmode"`
 	SslRootCert              string      `json:"sslrootcert" mapstructure:"sslrootcert" structs:"sslrootcert"`
+	SslSni                   string      `json:"sslsni" mapstructure:"sslsni" structs:"sslsni"`
+	SslKey                   string      `json:"sslkey" mapstructure:"sslkey" structs:"sslkey"`
+	SslCert                  string      `json:"sslcert" mapstructure:"sslcert" structs:"sslcert"`
+	SslPassword              string      `json:"sslpassword" mapstructure:"sslpassword" structs:"sslpassword"`
 
 	Type                  string
 	RawConfig             map[string]interface{}
@@ -137,17 +141,36 @@ func (c *YugabyteDBConnectionProducer) Connection(ctx context.Context) (interfac
 	}
 
 	if c.SslMode == "" {
-		c.SslMode = "disable"
-		c.SslRootCert = ""
+		c.SslMode = "prefer" //default sslmode
 	}
 
 	var conn string
 	if c.TopologyKeys != "" {
 		conn = fmt.Sprintf("host=%s port=%d user=%s "+
-			"password=%s dbname=%s sslmode=%s sslrootcert=%s load_balance=%v yb_servers_refresh_interval=%d topology_keys=%s ", c.Host, c.Port, c.Username, c.Password, c.DbName, c.SslMode, c.SslRootCert, c.LoadBalance, c.YbServersRefreshInterval, c.TopologyKeys)
+			"password=%s dbname=%s sslmode=%s load_balance=%v yb_servers_refresh_interval=%d topology_keys=%s ", c.Host, c.Port, c.Username, c.Password, c.DbName, c.SslMode, c.LoadBalance, c.YbServersRefreshInterval, c.TopologyKeys)
 	} else {
 		conn = fmt.Sprintf("host=%s port=%d user=%s "+
-			"password=%s dbname=%s sslmode=%s sslrootcert=%s load_balance=%v yb_servers_refresh_interval=%d ", c.Host, c.Port, c.Username, c.Password, c.DbName, c.SslMode, c.SslRootCert, c.LoadBalance, c.YbServersRefreshInterval)
+			"password=%s dbname=%s sslmode=%s load_balance=%v yb_servers_refresh_interval=%d ", c.Host, c.Port, c.Username, c.Password, c.DbName, c.SslMode, c.LoadBalance, c.YbServersRefreshInterval)
+	}
+
+	if c.SslRootCert != "" {
+		conn = fmt.Sprintf(conn + fmt.Sprintf("sslrootcert=%s ", c.SslRootCert))
+	}
+
+	if c.SslCert != "" {
+		conn = fmt.Sprintf(conn + fmt.Sprintf("sslcert=%s ", c.SslCert))
+	}
+
+	if c.SslKey != "" {
+		conn = fmt.Sprintf(conn + fmt.Sprintf("sslkey=%s ", c.SslKey))
+	}
+
+	if c.SslPassword != "" {
+		conn = fmt.Sprintf(conn + fmt.Sprintf("sslpassword=%s ", c.SslPassword))
+	}
+
+	if c.SslSni != "" {
+		conn = fmt.Sprintf(conn + fmt.Sprintf("sslsni=%s", c.SslSni))
 	}
 
 	if len(c.ConnectionURL) != 0 {

--- a/ysql_test.go
+++ b/ysql_test.go
@@ -440,6 +440,7 @@ func TestUpdateUser_Expiration(t *testing.T) {
 	// Shared test container for speed - there should not be any overlap between the tests
 	db, cleanup := getysql(t, nil)
 	defer cleanup()
+	db.db.SetMaxOpenConns(1)
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {

--- a/ysqlhelper/ysqlhelper.go
+++ b/ysqlhelper/ysqlhelper.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"net/url"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/vault/sdk/helper/docker"
 
@@ -51,6 +52,8 @@ func PrepareTestContainer(t *testing.T, version string) (func(), string) {
 }
 
 func connectYugabyteDB(ctx context.Context, host string, port int) (docker.ServiceConfig, error) {
+	fmt.Println("Waiting for container to be up...")
+	time.Sleep(30 * time.Second)
 	u := url.URL{
 		Scheme:   "postgres",
 		User:     url.UserPassword("yugabyte", "testsecret"),


### PR DESCRIPTION
# Describe your changes
This PR enables users to connect to SSL enabled cluster using Data Source Name (DSN) format url.

## Issue ticket number and link
[DB-11455](https://yugabyte.atlassian.net/browse/DB-11455)

## Description
This PR includes the following changes:

- Allow users to set `sslmode`, `sslrootcert`, `sslkey`, `sslcert`, `sslpassword` and `sslsni` via DSN format url, to connect to ssl enabled cluster.
- Added 30 sec sleep to wait for docker conatiner to come up when running any test.
- Fixed ` ERROR: The catalog snapshot used for this transaction has been invalidated: expected: 2, got: 1: MISMATCHED_SCHEMA (SQLSTATE 40001)` intermittent failure of a test by setting maxOpenConns to 1.

## How Has This Been Tested?
- Ran the unit tests locally multiple times using `go test -v`
- Tested `sslmode=verify-full` with a local ssl enabled 3 node cluster (`sslmode` and `sslrootcrt` provided in the DSN url):
- Testing the following `sslmode` with a local ssl enabled single node cluster (`sslmode` and `sslrootcrt` provided in the DSN url):
  - allow: connects with or without `sslrootcrt`
  - prefer: connects with or without `sslrootcrt`
  - require: connects with or without `sslrootcrt`
  - verify-ca: connects only with `sslrootcrt`
  - verify-full: connects only with `sslrootcrt`
 - Testing the following `sslmode` with a local non-ssl cluster:
   - disable: connects