### PR TITLE
Docker command fix for tests

### DIFF
--- a/ysql_test.go
+++ b/ysql_test.go
@@ -533,7 +533,7 @@ func getExpiration(t testing.TB, db *ysql, username string) time.Time {
 		return time.Time{} // No expiration
 	}
 
-	exp, err := time.Parse("2006-01-02 15:04:05Z07", rawExp) //time.RFC3339
+	exp, err := time.Parse(time.RFC3339, rawExp) //time.RFC3339
 	if err != nil {
 		t.Fatalf("Failed to parse expiration %q: %s", rawExp, err)
 	}

--- a/ysql_test.go
+++ b/ysql_test.go
@@ -61,6 +61,25 @@ func getysql(t *testing.T, options map[string]interface{}) (*ysql, func()) {
 	return db, cleanup
 }
 
+func getVersion(t *testing.T, db *ysql) string {
+
+	rows := db.db.QueryRow("select version()")
+
+	var version string
+	err := rows.Scan(&version)
+	if err != nil {
+		t.Fatalf("Unable to get database version: %s", err)
+	}
+
+	if strings.Contains(version, "PostgreSQL 11") {
+		version = "11"
+	} else {
+		version = "15"
+	}
+
+	return version
+}
+
 func TestYsql_Initialize(t *testing.T) {
 	db, cleanup := getysql(t, map[string]interface{}{
 		"max_open_connections": 5,
@@ -441,6 +460,7 @@ func TestUpdateUser_Expiration(t *testing.T) {
 	db, cleanup := getysql(t, nil)
 	defer cleanup()
 	db.db.SetMaxOpenConns(1)
+	version := getVersion(t, db)
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
@@ -461,7 +481,7 @@ func TestUpdateUser_Expiration(t *testing.T) {
 
 			assertCredsExist(t, db.ConnectionURL, createResp.Username, password)
 
-			actualExpiration := getExpiration(t, db, createResp.Username)
+			actualExpiration := getExpiration(t, db, createResp.Username, version)
 			if actualExpiration.IsZero() {
 				t.Fatalf("Initial expiration is zero but should be set")
 			}
@@ -491,7 +511,7 @@ func TestUpdateUser_Expiration(t *testing.T) {
 			}
 
 			expectedExpiration := test.expectedExpiration.Truncate(time.Second)
-			actualExpiration = getExpiration(t, db, createResp.Username)
+			actualExpiration = getExpiration(t, db, createResp.Username, version)
 			if !actualExpiration.Equal(expectedExpiration) {
 				t.Fatalf("Actual expiration: %s Expected expiration: %s", actualExpiration, expectedExpiration)
 			}
@@ -499,7 +519,7 @@ func TestUpdateUser_Expiration(t *testing.T) {
 	}
 }
 
-func getExpiration(t testing.TB, db *ysql, username string) time.Time {
+func getExpiration(t testing.TB, db *ysql, username string, version string) time.Time {
 	t.Helper()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
@@ -533,7 +553,12 @@ func getExpiration(t testing.TB, db *ysql, username string) time.Time {
 		return time.Time{} // No expiration
 	}
 
-	exp, err := time.Parse(time.RFC3339, rawExp) //time.RFC3339
+	var exp time.Time
+	if version == "15" {
+		exp, err = time.Parse(time.RFC3339, rawExp)
+	} else {
+		exp, err = time.Parse("2006-01-02 15:04:05Z07", rawExp)
+	}
 	if err != nil {
 		t.Fatalf("Failed to parse expiration %q: %s", rawExp, err)
 	}

--- a/ysqlhelper/ysqlhelper.go
+++ b/ysqlhelper/ysqlhelper.go
@@ -33,7 +33,7 @@ func PrepareTestContainer(t *testing.T, version string) (func(), string) {
 
 	runner, err := docker.NewServiceRunner(docker.RunOptions{
 		ImageRepo:     "yugabytedb/yugabyte",
-		Cmd:           []string{"./bin/yugabyted", "start", "--daemon=false"},
+		Cmd:           []string{"bash", "-c", "CONTAINER_IP=$(hostname -I | awk '{print $1}') && ./bin/yugabyted start --advertise_address=$CONTAINER_IP --background=false"},
 		ImageTag:      version,
 		Env:           []string{"YSQL_DB=testdb", "YSQL_PASSWORD=testsecret", "POSTGRES_DB=testdb", "POSTGRES_PASSWORD=testsecret"},
 		Ports:         []string{"5433/tcp"},


### PR DESCRIPTION
This PR implements the following 2 changes in **tests**:

- Changed the docker command to start the cluster on docker container IP-address, so that the cluster can be accessed outside the container using container IP. This is required because the yugabyted behaviour has changes in docker to use the container name as the Ip address for the cluster by default.
- Check database version in `TestUpdateUser_Expiration` since the data-type of `valuntil` column of the `pg_catalog.pg_user` table is `abstime` in PG 11 and `timestamp with time zone` in PG15, due to which we need different time format to parse it for the respective PG versions.

Debug Pipeline run: https://jenkins.dev.yugabyte.com/job/users/job/ecosystem-integration-debug/248/